### PR TITLE
Rework Table API

### DIFF
--- a/src/asgn_spec.rs
+++ b/src/asgn_spec.rs
@@ -217,7 +217,6 @@ impl AsgnSpec {
         )
     }
 
-
     pub fn before_open(&self) -> bool {
         self.open_date.map(|date| {
             Local::now().checked_add_days(chrono::naive::Days::new(1)).unwrap()
@@ -242,24 +241,16 @@ impl AsgnSpec {
 
         let status = slot.status().unwrap();
 
-        let mut table = Table::new(2);
-        table.add_row(vec!["PROPERTY".to_owned(), "VALUE".to_owned()])?;
-        table.add_row(vec!["NAME".to_owned(), self.name.clone()])?;
-        table.add_row(vec!["FILES".to_owned(), self.file_list.iter().join(" ")])?;
-        table.add_row(vec![
-            "OPEN DATE".to_owned(),
-            self.open_date.as_ref().map(|d| d.to_string()).unwrap_or("NONE".to_owned()),
+        let mut table = Table::new(["PROPERTY".to_owned(), "VALUE".to_owned()]);
+        table.extend([
+            ["NAME".to_owned(), self.name.clone()],
+            ["FILES".to_owned(), self.file_list.iter().join(" ")],
+            ["OPEN DATE".to_owned(), Table::option_repr(self.open_date.as_ref())],
+            ["CLOSE DATE".to_owned(), Table::option_repr(self.close_date.as_ref())],
+            ["DUE DATE".to_owned(), Table::option_repr(self.due_date.as_ref())],
+            ["EXTENSION".to_owned(), status.extension_days.to_string()],
+            ["GRACE".to_owned(), status.grace_days.to_string()],
         ])?;
-        table.add_row(vec![
-            "CLOSE DATE".to_owned(),
-            self.close_date.map(|d| d.to_string()).unwrap_or("NONE".to_owned()),
-        ])?;
-        table.add_row(vec![
-            "DUE DATE".to_owned(),
-            self.due_date.map(|d| d.to_string()).unwrap_or("NONE".to_owned()),
-        ])?;
-        table.add_row(vec!["EXTENSION".to_owned(), status.extension_days.to_string()])?;
-        table.add_row(vec!["GRACE".to_owned(), status.grace_days.to_string()])?;
 
         Ok(table)
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,6 +9,7 @@ pub enum Error {
     FormatFail(String),
     StyleFail(String),
     TestFail(String),
+    TableError,
     NoSpec(String, String),
     BadSpec(String, String),
     IOFail(String),
@@ -48,6 +49,7 @@ impl Error {
             FormatFail(err)     => format!("{}\n\n{}", "Failed to format files. Error:".red(), err),
             StyleFail(err)      => format!("{}\n\n{}", "Failed to check style. Error:".red(), err),
             TestFail(err)       => format!("{}\n\n{}", "Failed to test functionality due to internal error. Error:".red(), err),
+            TableError          => format!("{}", "Failure while constructing output table.".red()),
             MissingFile(name)   => format!("{} '{}' {}", "File".red(), name, "does not exist in current working directory.".red()),
             MissingSub(name)    => format!("{} '{}' {}", "File".red(), name, "does not exist in the submission directory".red()),
             FileIsDir(name)     => format!("{} '{}' {}", "File".red(), name, "is actually a directory".red()),
@@ -73,6 +75,7 @@ impl Error {
             | IOFail(_)
             | InvalidUID(_)
             | TestFail(_)
+            | TableError
             | Unauthorized() => format!("{}", "Please contact the instructor.".yellow()),
 
             InvalidAsgn(_)

--- a/src/table.rs
+++ b/src/table.rs
@@ -1,8 +1,17 @@
 use core::fmt;
 
-use crate::error::Error;
+use crate::error;
 use colored::Colorize;
 use itertools::Itertools;
+
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub struct Error;
+
+impl From<Error> for error::Error {
+    fn from(_: Error) -> Self {
+        error::Error::TableError
+    }
+}
 
 pub struct Table {
     width: usize,
@@ -10,38 +19,38 @@ pub struct Table {
 }
 
 impl Table {
-    pub fn new(width: usize) -> Self {
+    pub const NONE_REPR: &'static str = "NONE";
+
+    pub fn new(header: impl Into<Box<[String]>>) -> Self {
+        let header = header.into();
         Table {
-            width,
-            rows: Vec::new(),
+            width: header.len(),
+            rows: vec![header],
         }
     }
 
-    pub fn add_row(&mut self, row: impl Into<Box<[String]>>) -> Result<(), Error> {
-        let row = row.into();
+    pub fn extend<Row: Into<Box<[String]>>, I: IntoIterator<Item=Row>>(&mut self, rows: I) -> Result<(), Error> {
+        let rows = rows.into_iter();
+        self.rows.reserve(rows.size_hint().0);
 
-        if row.len() != self.width {
-            return Err(Error::Custom(
-                "Internal Error: Attempted to add a row to a table with a different width".to_owned(),
-                "Contact the instructor.".to_owned()
-            ));
-        }
-
-        self.rows.push(row);
-        Ok(())
-    }
-
-    fn as_table_row(row: &[String], col_widths: &[usize]) -> String {
-        row.iter()
-            .zip(col_widths)
-            .map(|(text, width)| format!(" {text:width$} "))
-            .join("|")
+        rows.map(Row::into).try_for_each(|row|
+            if row.len() == self.width {
+                self.rows.push(row);
+                Ok(())
+            } else {
+                Err(Error)
+            }
+        )
     }
 
     pub fn as_csv(&self) -> String {
         self.rows.iter()
             .map(|row| row.iter().join(","))
             .join("\n")
+    }
+
+    pub fn option_repr(value: Option<impl fmt::Display>) -> String {
+        value.as_ref().map(ToString::to_string).unwrap_or_else(|| Self::NONE_REPR.to_owned())
     }
 }
 
@@ -55,7 +64,11 @@ impl fmt::Display for Table {
             .collect();
 
         for (i, row) in self.rows.iter().enumerate() {
-            let text = Self::as_table_row(row, &widths);
+            let text = row.iter()
+                .zip(&widths)
+                .map(|(text, width)| format!(" {text:width$} "))
+                .join("|");
+
             let styled = match i {
                 0 => text.reversed().to_string(),
                 i if i % 2 == 0 => text.on_bright_black().to_string(),


### PR DESCRIPTION
1. Exchange `Table::add_row` for a generic `Table::extend`
2. Make `Table::new` take the header row, instead of length
3. Add a local `Error` type and global `Error` variant for row width errors
4. Add a convenience function `Table::option_repr`
5. Use `array` literals instead of `Vec` literals where possible