### PR TITLE
Revamp output styling and Error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,8 +31,6 @@ name = "asgn"
 version = "0.1.0"
 dependencies = [
  "chrono",
- "colored",
- "crossterm",
  "dirs",
  "itertools",
  "serde",
@@ -126,45 +124,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "colored"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf2150cce219b664a8a70df7a1f933836724b503f8a413af9365b4dcc4d90b8"
-dependencies = [
- "lazy_static",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "core-foundation-sys"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
-
-[[package]]
-name = "crossterm"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67"
-dependencies = [
- "bitflags 1.3.2",
- "crossterm_winapi",
- "libc",
- "mio",
- "parking_lot",
- "signal-hook",
- "signal-hook-mio",
- "winapi",
-]
-
-[[package]]
-name = "crossterm_winapi"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "dirs"
@@ -320,32 +283,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4cd1a83af159aa67994778be9070f0ae1bd732942279cabb14f86f986a21456"
 
 [[package]]
-name = "lock_api"
-version = "0.4.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
-dependencies = [
- "autocfg",
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
-
-[[package]]
-name = "mio"
-version = "0.8.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
-dependencies = [
- "libc",
- "log",
- "wasi",
- "windows-sys 0.48.0",
-]
 
 [[package]]
 name = "num-traits"
@@ -373,29 +314,6 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
-
-[[package]]
-name = "parking_lot"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-targets 0.48.5",
-]
 
 [[package]]
 name = "proc-macro-error"
@@ -488,12 +406,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
 name = "serde"
 version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -524,17 +436,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "signal-hook-mio"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af"
-dependencies = [
- "libc",
- "mio",
- "signal-hook",
-]
-
-[[package]]
 name = "signal-hook-registry"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -542,12 +443,6 @@ checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "smallvec"
-version = "1.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
 
 [[package]]
 name = "strsim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-crossterm = "0.25.0"
 chrono = "0.4.23"
 users = "0.11.0"
 signal-hook = "0.3.14"
@@ -14,7 +13,6 @@ toml = "0.5.10"
 serde = "1.0.152"
 serde_derive = "1.0.152"
 structopt = "0.3.26"
-colored = "2.0.4"
 dirs = "5.0.1"
 itertools = "0.12.0"
 termion = "2.0.3"

--- a/src/act/grader.rs
+++ b/src/act/grader.rs
@@ -100,11 +100,11 @@ impl GraderAct {
             return Ok(());
         }
 
-        util::print_bold_hline();
+        println!("{}", util::Hline::Bold);
         println!("{}", "Evaluating Grades".yellow().bold());
         let _ = spec.run_ruleset(context, spec.grade.as_ref(), &cwd, true);
 
-        util::print_bold_hline();
+        println!("{}", util::Hline::Bold);
 
         Ok(())
     }
@@ -112,11 +112,11 @@ impl GraderAct {
     fn check(asgn_name: &str, context: &Context) -> Result<(), Error> {
         let spec = context.catalog_get(asgn_name)?;
 
-        util::print_bold_hline();
+        println!("{}", util::Hline::Bold);
         println!("{}", "Evaluating Checks".yellow().bold());
         let cwd = context.cwd.clone();
         let _ = spec.run_ruleset(context, spec.check.as_ref(), &cwd, true);
-        util::print_bold_hline();
+        println!("{}", util::Hline::Bold);
 
         Ok(())
     }
@@ -124,11 +124,11 @@ impl GraderAct {
     fn score(asgn_name: &str, context: &Context) -> Result<(), Error> {
         let spec = context.catalog_get(asgn_name)?;
 
-        util::print_bold_hline();
+        println!("{}", util::Hline::Bold);
         println!("{}", "Evaluating Scores".yellow().bold());
         let cwd = context.cwd.clone();
         let _ = spec.run_ruleset(context, spec.score.as_ref(), &cwd, true);
-        util::print_bold_hline();
+        println!("{}", util::Hline::Bold);
 
         Ok(())
     }
@@ -154,7 +154,7 @@ impl GraderAct {
         if score_result == Some(Err(SubmissionFatal)) {
             return Ok(());
         }
-        util::print_bold_hline();
+        println!("{}", util::Hline::Bold);
 
         Ok(())
     }
@@ -167,9 +167,9 @@ impl GraderAct {
         for member_name in &context.members {
             println!("{}", format!("Retrieving Submission for '{member_name}'").bold());
             if let Err(err) = Self::copy(asgn_name, member_name, Some(&dst_dir), context) {
-                util::print_bold_hline();
+                println!("{}", util::Hline::Bold);
                 print!("{err}");
-                util::print_bold_hline();
+                println!("{}", util::Hline::Bold);
             }
         }
         Ok(())

--- a/src/act/grader.rs
+++ b/src/act/grader.rs
@@ -7,10 +7,8 @@ use crate::{
     asgn_spec::{AsgnSpec, SubmissionFatal},
     context::Context,
     error::{ErrorLog, Error},
-    util,
+    util::{self, color::{FG_YELLOW, TEXT_BOLD, STYLE_RESET}},
 };
-
-use colored::Colorize;
 
 #[derive(Debug, StructOpt)]
 #[structopt(
@@ -101,7 +99,7 @@ impl GraderAct {
         }
 
         println!("{}", util::Hline::Bold);
-        println!("{}", "Evaluating Grades".yellow().bold());
+        println!("{FG_YELLOW}{TEXT_BOLD}Evaluating Grades{STYLE_RESET}");
         let _ = spec.run_ruleset(context, spec.grade.as_ref(), &cwd, true);
 
         println!("{}", util::Hline::Bold);
@@ -113,7 +111,7 @@ impl GraderAct {
         let spec = context.catalog_get(asgn_name)?;
 
         println!("{}", util::Hline::Bold);
-        println!("{}", "Evaluating Checks".yellow().bold());
+        println!("{FG_YELLOW}{TEXT_BOLD}Evaluating Checks{STYLE_RESET}");
         let cwd = context.cwd.clone();
         let _ = spec.run_ruleset(context, spec.check.as_ref(), &cwd, true);
         println!("{}", util::Hline::Bold);
@@ -125,7 +123,7 @@ impl GraderAct {
         let spec = context.catalog_get(asgn_name)?;
 
         println!("{}", util::Hline::Bold);
-        println!("{}", "Evaluating Scores".yellow().bold());
+        println!("{FG_YELLOW}{TEXT_BOLD}Evaluating Scores{STYLE_RESET}");
         let cwd = context.cwd.clone();
         let _ = spec.run_ruleset(context, spec.score.as_ref(), &cwd, true);
         println!("{}", util::Hline::Bold);
@@ -165,7 +163,7 @@ impl GraderAct {
         );
         util::refresh_dir(&dst_dir, 0o700, Vec::new().iter())?;
         for member_name in &context.members {
-            println!("{}", format!("Retrieving Submission for '{member_name}'").bold());
+            println!("{TEXT_BOLD}Retrieving Submission for '{member_name}'{STYLE_RESET}");
             if let Err(err) = Self::copy(asgn_name, member_name, Some(&dst_dir), context) {
                 println!("{}", util::Hline::Bold);
                 print!("{err}");

--- a/src/act/instructor.rs
+++ b/src/act/instructor.rs
@@ -8,11 +8,10 @@ use crate:: {
     error:: {ErrorLog, Error},
     asgn_spec::{AsgnSpec, StatBlock, StatBlockSet},
     act::{student::StudentAct, grader::GraderAct},
-    util,
+    util::{self, color::{FG_YELLOW, TEXT_BOLD, STYLE_RESET}},
 };
 
 use structopt::StructOpt;
-use colored::Colorize;
 use tempfile::tempdir_in;
 use chrono::Duration;
 
@@ -364,7 +363,7 @@ impl InstructorAct {
         if let Some(stats) = stats {
             let old_time = util::date_into_chrono(stats.time.clone())?;
             if turn_in_time.signed_duration_since(old_time) <= Duration::seconds(1) {
-                println!("{}", format!("{username} is already up-to-date.").yellow().bold());
+                println!("{FG_YELLOW}{TEXT_BOLD}{username} is already up-to-date.{STYLE_RESET}");
                 return Ok(Some(stats.clone()));
             }
         }
@@ -412,7 +411,7 @@ impl InstructorAct {
                     new_stats.stat_block = Some(vec![block]);
                 }
                 Err(log) => print!("{log}"),
-                _ => println!("{}", format!("{member} has no submission.").yellow().bold()),
+                _ => println!("{FG_YELLOW}{TEXT_BOLD}{member} has no submission.{STYLE_RESET}"),
             }
         }
 

--- a/src/act/student.rs
+++ b/src/act/student.rs
@@ -314,7 +314,7 @@ impl StudentAct {
         }
         log.into_result()?;
 
-        util::print_bold_hline();
+        println!("{}", util::Hline::Bold);
         println!("{}", format!("Assignment '{asgn_name}' submitted!").green());
 
         let build_result = spec.run_on_submit(
@@ -350,7 +350,7 @@ impl StudentAct {
             return Ok(());
         }
 
-        util::print_bold_hline();
+        println!("{}", util::Hline::Bold);
         Ok(())
     }
 

--- a/src/act/student.rs
+++ b/src/act/student.rs
@@ -1,5 +1,4 @@
 use structopt::StructOpt;
-use colored::Colorize;
 use super::other::OtherAct;
 use util::bashrc_append_line;
 
@@ -9,7 +8,7 @@ use crate::{
     asgn_spec::{AsgnSpec, Ruleset, StatBlockSet, SubmissionFatal},
     context::{Context, Role},
     error::{Error, ErrorLog},
-    util,
+    util::{self, color::{FG_GREEN, STYLE_RESET, FG_YELLOW}},
     table::Table,
 };
 
@@ -315,7 +314,7 @@ impl StudentAct {
         log.into_result()?;
 
         println!("{}", util::Hline::Bold);
-        println!("{}", format!("Assignment '{asgn_name}' submitted!").green());
+        println!("{FG_GREEN}Assignment '{asgn_name}' submitted!{STYLE_RESET}");
 
         let build_result = spec.run_on_submit(
             context,
@@ -412,10 +411,12 @@ impl StudentAct {
             context.base_path.display(),
         );
         bashrc_append_line(&line)?;
-        println!("{}", "Alias installed successfully.".yellow());
-        println!("{}", "The alias will take effect automatically for future shell sessions.".yellow());
-        println!("{}", "\nTo have it take effect for this shell session, run this command:".yellow());
-        println!("{}", "\n\nsource ~/.bashrc\n\n".green());
+        println!(
+"{FG_YELLOW}Alias installed successfully.
+The alias will be present in future shell sessions.
+
+To import it for this shell session, run the command:
+  {FG_GREEN}source ~/.bashrc{STYLE_RESET}");
 
         Ok(())
     }

--- a/src/asgn_spec.rs
+++ b/src/asgn_spec.rs
@@ -2,7 +2,8 @@ use std::{
     fs,
     path::{PathBuf, Path},
     process::Stdio,
-    os::unix::fs::MetadataExt, io,
+    os::unix::fs::MetadataExt,
+    io,
 };
 
 use itertools::Itertools;
@@ -379,7 +380,7 @@ impl AsgnSpec {
 
         for mut rule in ruleset.rules.iter().cloned() {
             rule.fail_okay.get_or_insert(ruleset.fail_okay.unwrap_or(false));
-            util::print_hline();
+            println!("{}", util::Hline::Normal);
             let mut did_pass: bool = false;
 
             match self.run_rule(context, &rule, path) {
@@ -413,7 +414,7 @@ impl AsgnSpec {
         if fatal {
             println!("{}", format!("! {}", "Execution cannot continue beyond this error.").red());
         }
-        util::print_hline();
+        println!("{}", util::Hline::Normal);
         let not_reached = count-passed-failed;
         println!("! {count} total targets - {passed} passed, {failed} failed, {not_reached} not reached.");
 
@@ -435,7 +436,7 @@ impl AsgnSpec {
     {
         match ruleset {
             Some(Ruleset { on_submit: Some(true) | None, .. }) => {
-                util::print_bold_hline();
+                println!("{}", util::Hline::Bold);
                 println!("{}", title.yellow().bold());
                 Some(self.run_ruleset(context, ruleset, path, is_metric))
             }
@@ -454,7 +455,7 @@ impl AsgnSpec {
     {
         match ruleset {
             Some(Ruleset { on_grade: Some(true) | None, .. }) => {
-                util::print_bold_hline();
+                println!("{}", util::Hline::Bold);
                 println!("{}", title.yellow().bold());
                 Some(self.run_ruleset(context, ruleset, path, is_metric))
             }

--- a/src/table.rs
+++ b/src/table.rs
@@ -1,7 +1,6 @@
 use core::fmt;
 
-use crate::error;
-use colored::Colorize;
+use crate::{error, util::color::{STYLE_RESET, COLOR_REVERSED, BG_LIGHT_BLACK}};
 use itertools::Itertools;
 
 #[derive(Clone, Copy, PartialEq, Debug)]
@@ -69,12 +68,11 @@ impl fmt::Display for Table {
                 .map(|(text, width)| format!(" {text:width$} "))
                 .join("|");
 
-            let styled = match i {
-                0 => text.reversed().to_string(),
-                i if i % 2 == 0 => text.on_bright_black().to_string(),
-                _ => text
-            };
-            writeln!(f, "{styled}")?;
+            match i {
+                0 => writeln!(f, "{COLOR_REVERSED}{text}{STYLE_RESET}"),
+                i if i % 2 == 0 => writeln!(f, "{BG_LIGHT_BLACK}{text}{STYLE_RESET}"),
+                _ => writeln!(f, "{text}"),
+            }?
         }
 
         Ok(())

--- a/src/util.rs
+++ b/src/util.rs
@@ -13,9 +13,24 @@ use crate::error::Error;
 
 use toml;
 use termion::terminal_size;
-use colored::Colorize;
 use walkdir::WalkDir;
 use chrono::{TimeZone, Datelike, Timelike};
+
+pub mod color {
+    use termion::{color::*, style};
+
+    pub const FG_RED: Fg<Red> = Fg(Red);
+    pub const FG_GREEN: Fg<Green> = Fg(Green);
+    pub const FG_YELLOW: Fg<Yellow> = Fg(Yellow);
+
+    pub const BG_LIGHT_BLACK: Bg<LightBlack> = Bg(LightBlack);
+
+    pub const TEXT_BOLD: style::Bold = style::Bold;
+    pub const COLOR_REVERSED: style::Invert = style::Invert;
+    pub const STYLE_RESET: style::Reset = style::Reset;
+}
+
+use self::color::*;
 
 pub enum Hline { Normal, Bold }
 
@@ -24,7 +39,7 @@ impl fmt::Display for Hline {
         match terminal_size() {
             Ok((width, _)) => match self {
                 Self::Normal => write!(f, "{:-<1$}", "", width as usize),
-                Self::Bold => write!(f, "{}", format!("{:=<1$}", "", width as usize).bold()),
+                Self::Bold => write!(f, "{TEXT_BOLD}{:=<1$}{STYLE_RESET}", "", width as usize),
             }
             Err(_) => Ok(()),
         }

--- a/src/util.rs
+++ b/src/util.rs
@@ -17,17 +17,17 @@ use colored::Colorize;
 use walkdir::WalkDir;
 use chrono::{TimeZone, Datelike, Timelike};
 
-pub fn print_hline() {
-    match terminal_size() {
-        Ok((w, _)) => println!("{:-<1$}", "", w as usize),
-        Err(_) => println!(),
-    }
-}
+pub enum Hline { Normal, Bold }
 
-pub fn print_bold_hline () {
-    match terminal_size() {
-        Ok((w, _)) => println!("{}", format!("{:=<1$}", "", w as usize).bold()),
-        Err(_) => println!(),
+impl fmt::Display for Hline {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match terminal_size() {
+            Ok((width, _)) => match self {
+                Self::Normal => write!(f, "{:-<1$}", "", width as usize),
+                Self::Bold => write!(f, "{}", format!("{:=<1$}", "", width as usize).bold()),
+            }
+            Err(_) => Ok(()),
+        }
     }
 }
 


### PR DESCRIPTION
1. Use `termion` color instead of `colored` color
2. Use `Hline` struct instead of functions
3. Use a unified `Display` impl for `Error` that avoids allocations
4. Create a new error type for unknown course members